### PR TITLE
add timing patterns

### DIFF
--- a/packages/core/src/renderer/matrix.spec.ts
+++ b/packages/core/src/renderer/matrix.spec.ts
@@ -12,4 +12,47 @@ describe('renderer > matrix > generateMatrix', () => {
 
     expect(finderPatternArea).toEqual(FINDER_PATTERN)
   })
+
+  it('adds the timing patterns', () => {
+    const column6 = simpleStringMatrix[6].join('')
+
+    expect(column6).toEqual('111111101010101111111')
+
+    const row6 = simpleStringMatrix.map(column => column[6]).join('')
+
+    expect(row6).toEqual('111111101010101111111')
+  })
+
+  it('renders correct QR code', () => {
+    const toString = (item: 1 | 0 | null) =>
+      item === 0 ? '\u2591' : item === 1 ? '\u2593' : '\u00B7'
+
+    const result = simpleStringMatrix
+      .map(row => row.map(toString).join(' '))
+      .join('\n')
+
+    expect(result).toMatchInlineSnapshot(`
+      "▓ ▓ ▓ ▓ ▓ ▓ ▓ ░ · · · · · ░ ▓ ▓ ▓ ▓ ▓ ▓ ▓
+      ▓ ░ ░ ░ ░ ░ ▓ ░ · · · · · ░ ▓ ░ ░ ░ ░ ░ ▓
+      ▓ ░ ▓ ▓ ▓ ░ ▓ ░ · · · · · ░ ▓ ░ ▓ ▓ ▓ ░ ▓
+      ▓ ░ ▓ ▓ ▓ ░ ▓ ░ · · · · · ░ ▓ ░ ▓ ▓ ▓ ░ ▓
+      ▓ ░ ▓ ▓ ▓ ░ ▓ ░ · · · · · ░ ▓ ░ ▓ ▓ ▓ ░ ▓
+      ▓ ░ ░ ░ ░ ░ ▓ ░ · · · · · ░ ▓ ░ ░ ░ ░ ░ ▓
+      ▓ ▓ ▓ ▓ ▓ ▓ ▓ ░ ▓ ░ ▓ ░ ▓ ░ ▓ ▓ ▓ ▓ ▓ ▓ ▓
+      ░ ░ ░ ░ ░ ░ ░ ░ · · · · · ░ ░ ░ ░ ░ ░ ░ ░
+      · · · · · · ▓ · · · · · · · · · · · · · ·
+      · · · · · · ░ · · · · · · · · · · · · · ·
+      · · · · · · ▓ · · · · · · · · · · · · · ·
+      · · · · · · ░ · · · · · · · · · · · · · ·
+      · · · · · · ▓ · · · · · · · · · · · · · ·
+      ░ ░ ░ ░ ░ ░ ░ ░ ▓ · · · · · · · · · · · ·
+      ▓ ▓ ▓ ▓ ▓ ▓ ▓ ░ · · · · · · · · · · · · ·
+      ▓ ░ ░ ░ ░ ░ ▓ ░ · · · · · · · · · · · · ·
+      ▓ ░ ▓ ▓ ▓ ░ ▓ ░ · · · · · · · · · · · · ·
+      ▓ ░ ▓ ▓ ▓ ░ ▓ ░ · · · · · · · · · · · · ·
+      ▓ ░ ▓ ▓ ▓ ░ ▓ ░ · · · · · · · · · · · · ·
+      ▓ ░ ░ ░ ░ ░ ▓ ░ · · · · · · · · · · · · ·
+      ▓ ▓ ▓ ▓ ▓ ▓ ▓ ░ · · · · · · · · · · · · ·"
+    `)
+  })
 })

--- a/packages/core/src/renderer/matrix.ts
+++ b/packages/core/src/renderer/matrix.ts
@@ -56,7 +56,18 @@ export const generateMatrix = (encodingResult: EncodingResult): Matrix => {
 
   // TODO: add alignmentPatterns
 
-  // TODO: add timing patterns
+  // add timing patterns
+  for (let x = 0; x < qrCodeSize; x++) {
+    if (!matrix[x][6]) {
+      matrix[x][6] = x % 2 === 0 ? Pixel.BLACK : Pixel.WHITE
+    }
+  }
+
+  for (let y = 0; y < qrCodeSize; y++) {
+    if (!matrix[6][y]) {
+      matrix[6][y] = y % 2 === 0 ? Pixel.BLACK : Pixel.WHITE
+    }
+  }
 
   // adding dark module
   const [darkModuleX, darkModuleY] = calculateDarkModuleCoordinates(


### PR DESCRIPTION
This PR brings adds timing patterns to the code as described on https://www.thonky.com/qr-code-tutorial/module-placement-matrix.

Please note that this implementation does not interfere with the future addition of the Alignment Patterns.

The result after this step should look like this:

![timing-s](https://user-images.githubusercontent.com/68341/95749671-3ba48000-0c9c-11eb-8730-72ec93161fbd.png)

I also added a simple preview in the test. Let me know if that should be removed.